### PR TITLE
log -> logrus

### DIFF
--- a/ad/internal/config/config.go
+++ b/ad/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"runtime"

--- a/ad/internal/gposec/inihelper.go
+++ b/ad/internal/gposec/inihelper.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/ad/internal/winrmhelper/powershell_command.go
+++ b/ad/internal/winrmhelper/powershell_command.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/xml"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/internal/winrmhelper/winrm_computer.go
+++ b/ad/internal/winrmhelper/winrm_computer.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/internal/winrmhelper/winrm_gplink.go
+++ b/ad/internal/winrmhelper/winrm_gplink.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/ad/internal/winrmhelper/winrm_gpo.go
+++ b/ad/internal/winrmhelper/winrm_gpo.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/ad/internal/winrmhelper/winrm_group.go
+++ b/ad/internal/winrmhelper/winrm_group.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/internal/winrmhelper/winrm_helper.go
+++ b/ad/internal/winrmhelper/winrm_helper.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os/exec"
 	"reflect"
 	"sort"

--- a/ad/internal/winrmhelper/winrm_ou.go
+++ b/ad/internal/winrmhelper/winrm_ou.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/internal/winrmhelper/winrm_sec.go
+++ b/ad/internal/winrmhelper/winrm_sec.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/internal/winrmhelper/winrm_user.go
+++ b/ad/internal/winrmhelper/winrm_user.go
@@ -3,7 +3,7 @@ package winrmhelper
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 

--- a/ad/resource_ad_gpo_security.go
+++ b/ad/resource_ad_gpo_security.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"

--- a/ad/resource_ad_user.go
+++ b/ad/resource_ad_user.go
@@ -2,7 +2,7 @@ package ad
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/interceptlogger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"runtime"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"time"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-hclog/stdlog.go
+++ b/vendor/github.com/hashicorp/go-hclog/stdlog.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 )

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/checkpoint/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/vendor/github.com/hashicorp/hc-install/fs/any_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/any_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path/filepath"
 
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/exact_version.go
@@ -3,7 +3,7 @@ package fs
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path/filepath"
 	"time"
 

--- a/vendor/github.com/hashicorp/hc-install/fs/fs.go
+++ b/vendor/github.com/hashicorp/hc-install/fs/fs.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/installer.go
+++ b/vendor/github.com/hashicorp/hc-install/installer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hc-install/errors"

--- a/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/build/go_build.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/checksum_downloader.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
 

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/downloader.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/internal/releasesjson/releases.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strings"
 

--- a/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/exact_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"time"

--- a/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/latest_version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/hc-install/releases/releases.go
+++ b/vendor/github.com/hashicorp/hc-install/releases/releases.go
@@ -2,7 +2,7 @@ package releases
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/hc-install/src/src.go
+++ b/vendor/github.com/hashicorp/hc-install/src/src.go
@@ -2,7 +2,7 @@ package src
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	isrc "github.com/hashicorp/hc-install/internal/src"
 )

--- a/vendor/github.com/hashicorp/hcl/v2/doc.go
+++ b/vendor/github.com/hashicorp/hcl/v2/doc.go
@@ -9,7 +9,7 @@
 //     package main
 //
 //     import (
-//     	"log"
+//     	log "github.com/sirupsen/logrus"
 //     	"github.com/hashicorp/hcl/v2/hclsimple"
 //     )
 //

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sirupsen/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfexec/terraform.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-go/internal/logging/provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/internal/logging/provider.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfaddr "github.com/hashicorp/terraform-registry-address"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/logging.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/plugin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/plugin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"regexp"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"sort"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/mitchellh/copystructure"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
@@ -14,7 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"regexp"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugin/convert/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugin/convert/schema.go
@@ -2,7 +2,7 @@ package convert
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/plugin/serve.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/terraform/state.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/jcmturner/gokrb5/v8/client/settings.go
+++ b/vendor/github.com/jcmturner/gokrb5/v8/client/settings.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // Settings holds optional client settings.

--- a/vendor/github.com/jcmturner/gokrb5/v8/messages/Ticket.go
+++ b/vendor/github.com/jcmturner/gokrb5/v8/messages/Ticket.go
@@ -2,7 +2,7 @@ package messages
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"

--- a/vendor/github.com/jcmturner/gokrb5/v8/pac/pac_type.go
+++ b/vendor/github.com/jcmturner/gokrb5/v8/pac/pac_type.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana/keyusage"

--- a/vendor/github.com/jcmturner/gokrb5/v8/service/settings.go
+++ b/vendor/github.com/jcmturner/gokrb5/v8/service/settings.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
 

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -2,7 +2,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/packer-community/winrmcp/winrmcp/cp.go
+++ b/vendor/github.com/packer-community/winrmcp/winrmcp/cp.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"sync"
 

--- a/vendor/github.com/packer-community/winrmcp/winrmcp/ls.go
+++ b/vendor/github.com/packer-community/winrmcp/winrmcp/ls.go
@@ -3,7 +3,7 @@ package winrmcp
 import (
 	"encoding/xml"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 

--- a/vendor/github.com/vmihailenco/msgpack/v4/types.go
+++ b/vendor/github.com/vmihailenco/msgpack/v4/types.go
@@ -3,7 +3,7 @@ package msgpack
 import (
 	"encoding"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -6,7 +6,7 @@ package bidi
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 // This implementation is a port based on the reference implementation found at:

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"strings"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)